### PR TITLE
Add get_addon_version() helper

### DIFF
--- a/resources/lib/bossanova808/utilities.py
+++ b/resources/lib/bossanova808/utilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 import re
 import xbmc
+import xbmcaddon
 import xbmcgui
 import xbmcvfs
 import xml.etree.ElementTree as ElementTree
@@ -215,6 +216,22 @@ def is_playback_paused() -> bool:
     :return: Boolean indicating the player paused state
     """
     return bool(xbmc.getCondVisibility("Player.Paused"))
+
+
+def get_addon_version(addon_id) -> str | None:
+    """
+    Helper function to return the currently installed version of Kodi addon by its ID.
+
+    :param addon_id: the ID of the addon, e.g. weather.ozweather
+    :return: the version string (e.g. "0.0.1"), or None if the addon is not installed and enabled
+    """
+    try:
+        addon = xbmcaddon.Addon(id=addon_id)
+        version = addon.getAddonInfo('version')
+        return version
+    except Exception as e:
+        Logger.error(f"Error getting version for {addon_id}")
+        Logger.error(e)
 
 
 def footprints(startup: bool = True) -> None:

--- a/resources/lib/bossanova808/utilities.py
+++ b/resources/lib/bossanova808/utilities.py
@@ -218,7 +218,7 @@ def is_playback_paused() -> bool:
     return bool(xbmc.getCondVisibility("Player.Paused"))
 
 
-def get_addon_version(addon_id) -> str | None:
+def get_addon_version(addon_id: str) -> str | None:
     """
     Helper function to return the currently installed version of Kodi addon by its ID.
 
@@ -229,9 +229,10 @@ def get_addon_version(addon_id) -> str | None:
         addon = xbmcaddon.Addon(id=addon_id)
         version = addon.getAddonInfo('version')
         return version
-    except Exception as e:
+    except RuntimeError as e:
         Logger.error(f"Error getting version for {addon_id}")
         Logger.error(e)
+        return None
 
 
 def footprints(startup: bool = True) -> None:

--- a/resources/lib/bossanova808/utilities.py
+++ b/resources/lib/bossanova808/utilities.py
@@ -228,11 +228,12 @@ def get_addon_version(addon_id: str) -> str | None:
     try:
         addon = xbmcaddon.Addon(id=addon_id)
         version = addon.getAddonInfo('version')
-        return version
     except RuntimeError as e:
         Logger.error(f"Error getting version for {addon_id}")
         Logger.error(e)
         return None
+
+    return version
 
 
 def footprints(startup: bool = True) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a utility to retrieve an add-on’s version, returning a safe result when the version is unavailable to reduce errors for dependent components.
  - Enhanced error handling and logging around version lookups to improve diagnostics and robustness.
  - Preserves existing behavior elsewhere; no user-facing UI changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->