### PR TITLE
Add `get_resume_point` and `get_playcount`

### DIFF
--- a/resources/lib/bossanova808/utilities.py
+++ b/resources/lib/bossanova808/utilities.py
@@ -272,7 +272,7 @@ def get_resume_point(library_type: str, dbid: int) -> float | None:
         try:
             resume_point = result[result_key]['resume']['position']
         except (KeyError, TypeError) as e:
-            Logger.error(f"Could not get resume point")
+            Logger.error("Could not get resume point")
             Logger.error(e)
             resume_point = None
     else:
@@ -281,10 +281,10 @@ def get_resume_point(library_type: str, dbid: int) -> float | None:
 
     Logger.info(f"Resume point retrieved: {resume_point}")
 
-    return resume_point if resume_point is not None else None
+    return resume_point
 
 
-def get_playcount(library_type: str, dbid: int):
+def get_playcount(library_type: str, dbid: int) -> int | None:
     """
     Get the playcount for the given Kodi DB item
 
@@ -298,10 +298,6 @@ def get_playcount(library_type: str, dbid: int):
     if not params:
         return None
     get_method, id_name, result_key = params
-
-    # Short circuit if there is an issue get the JSON RPC method etc.
-    if not get_method:
-        return None
 
     json_dict = {
             "jsonrpc":"2.0",
@@ -324,7 +320,7 @@ def get_playcount(library_type: str, dbid: int):
         try:
             play_count = result[result_key]['playcount']
         except (KeyError, TypeError) as e:
-            Logger.error(f"Could not get playcount")
+            Logger.error("Could not get playcount")
             Logger.error(e)
             play_count = None
     else:
@@ -333,7 +329,7 @@ def get_playcount(library_type: str, dbid: int):
 
     Logger.info(f"Playcount retrieved: {play_count}")
 
-    return play_count if play_count is not None else None
+    return play_count
 
 
 def footprints(startup: bool = True) -> None:
@@ -349,7 +345,7 @@ def footprints(startup: bool = True) -> None:
         Logger.stop()
 
 
-def _get_jsonrpc_video_lib_params(library_type: str):
+def _get_jsonrpc_video_lib_params(library_type: str) -> tuple[str, str, str] | None:
     """
     Given a Kodi library type, return the JSON RPC library parameters needed to get details
 

--- a/resources/lib/bossanova808/utilities.py
+++ b/resources/lib/bossanova808/utilities.py
@@ -245,11 +245,11 @@ def get_resume_point(library_type: str, dbid: int) -> float | None:
     :return: the resume point, or None if there isn't one set
     """
 
-    get_method, id_name, result_key = _get_jsonrpc_video_lib_params(library_type)
-
+    params = _get_jsonrpc_video_lib_params(library_type)
     # Short circuit if there is an issue get the JSON RPC method etc.
-    if not get_method:
+    if not params:
         return None
+    get_method, id_name, result_key = params
 
     json_dict = {
             "jsonrpc":"2.0",
@@ -263,6 +263,10 @@ def get_resume_point(library_type: str, dbid: int) -> float | None:
 
     query = json.dumps(json_dict)
     json_response = send_kodi_json(f'Get resume point for {library_type} with dbid: {dbid}', query)
+    if not json_response:
+        Logger.error("Nothing returned from JSON-RPC query")
+        return None
+
     result = json_response.get('result')
     if result:
         try:
@@ -277,7 +281,7 @@ def get_resume_point(library_type: str, dbid: int) -> float | None:
 
     Logger.info(f"Resume point retrieved: {resume_point}")
 
-    return resume_point if resume_point else None
+    return resume_point if resume_point is not None else None
 
 
 def get_playcount(library_type: str, dbid: int):
@@ -289,7 +293,11 @@ def get_playcount(library_type: str, dbid: int):
     :return: the playcount if there is one, or None
     """
 
-    get_method, id_name, result_key = _get_jsonrpc_video_lib_params(library_type)
+    params = _get_jsonrpc_video_lib_params(library_type)
+    # Short circuit if there is an issue get the JSON RPC method etc.
+    if not params:
+        return None
+    get_method, id_name, result_key = params
 
     # Short circuit if there is an issue get the JSON RPC method etc.
     if not get_method:
@@ -307,6 +315,10 @@ def get_playcount(library_type: str, dbid: int):
 
     query = json.dumps(json_dict)
     json_response = send_kodi_json(f'Get playcount for {library_type} with dbid: {dbid}', query)
+    if not json_response:
+        Logger.error("Nothing returned from JSON-RPC query")
+        return None
+
     result = json_response.get('result')
     if result:
         try:
@@ -321,7 +333,7 @@ def get_playcount(library_type: str, dbid: int):
 
     Logger.info(f"Playcount retrieved: {play_count}")
 
-    return play_count if play_count else None
+    return play_count if play_count is not None else None
 
 
 def footprints(startup: bool = True) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve resume positions and play counts for movies, episodes, and music videos to improve playback continuity and viewing stats.

* **Bug Fixes**
  * Graceful handling when data is missing or when unsupported media types are requested, avoiding errors and fallback failures.

* **Performance/Reliability**
  * Consistent request/response parsing and centralized error logging for playback data, improving reliability and reducing intermittent issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->